### PR TITLE
Issue #6 - Various PHP 8 Issues

### DIFF
--- a/h5p.admin.inc
+++ b/h5p.admin.inc
@@ -545,7 +545,7 @@ function h5p_content_type_cache_update_form($form_state) {
   );
 
   $last_updated = config_get('h5p.settings', 'h5p_content_type_cache_updated_at');
-  $date_formatted = $last_updated ? format_date($last_updated) : t('Never');
+  $date_formatted = ($last_updated && $last_updated != "false") ? format_date($last_updated) : t('Never');
 
   $form['h5p_content_type_cache_last_updated'] = array(
     '#type' => 'item',

--- a/library/h5p-development.class.php
+++ b/library/h5p-development.class.php
@@ -67,7 +67,7 @@ class H5PDevelopment {
     $contents = scandir($path);
 
     for ($i = 0, $s = count($contents); $i < $s; $i++) {
-      if ($contents[$i]{0} === '.') {
+      if ($contents[$i][0] === '.') {
         continue; // Skip hidden stuff.
       }
 

--- a/library/h5p.classes.php
+++ b/library/h5p.classes.php
@@ -2114,6 +2114,12 @@ class H5PCore {
     self::DISABLE_COPYRIGHT => self::DISPLAY_OPTION_COPYRIGHT
   );
 
+  public $url;
+  public $development_mode;
+  public $aggregateAssets;
+  public $fullPluginPath;
+  public $relativePathRegExp;
+
   /**
    * Constructor for the H5PCore
    *
@@ -2806,7 +2812,7 @@ class H5PCore {
     foreach ($arr as $key => $val) {
       $next = -1;
       while (($next = strpos($key, '_', $next + 1)) !== FALSE) {
-        $key = substr_replace($key, strtoupper($key{$next + 1}), $next, 2);
+        $key = substr_replace($key, strtoupper($key[$next + 1]), $next, 2);
       }
 
       $newArr[$key] = $val;

--- a/modules/h5peditor/h5peditor-backdrop-storage.class.inc
+++ b/modules/h5peditor/h5peditor-backdrop-storage.class.inc
@@ -118,7 +118,7 @@ class H5peditorBackdropStorage implements H5peditorStorage {
           $library->title = $details->title;
           $library->runnable = $details->runnable;
           $library->restricted = $super_user ? FALSE : ($details->restricted === '1' ? TRUE : FALSE);
-          $library->metadataSettings = json_decode($details->metadata_settings);
+          $library->metadataSettings = (!empty($details->metadata_settings)) ? json_decode($details->metadata_settings) : NULL;
           $librariesWithDetails[] = $library;
         }
       }


### PR DESCRIPTION
Fixed issue with deprecated dynamic properties of classes (as of PHP 8.2)
Fixed an issue with last updated date that was causing errors if set to false. 
Formatting to replace curly braces with brackets for array references